### PR TITLE
Netperf updates

### DIFF
--- a/network-streaming-performance-k8s/input-example.yaml
+++ b/network-streaming-performance-k8s/input-example.yaml
@@ -1,7 +1,7 @@
 run_id: example_run_id
 uperf_protocol: tcp
 uperf_nthreads: 1
-uperf_kbytes: 64
+uperf_bytes: 64
 uperf_runtime_seconds: 10
 #Currently the server component requies a separate timeout value. This should be greater than the uperf_runtime_seconds.
 uperf_server_timeout_seconds: 40

--- a/network-streaming-performance-k8s/workflow.yaml
+++ b/network-streaming-performance-k8s/workflow.yaml
@@ -34,7 +34,7 @@ input:
           required: true
         uperf_bytes:
           display:
-            description: The uperf workload packet size in KiB
+            description: The uperf workload packet size in bytes
             name: uperf size
           type:
             type_id: integer

--- a/network-streaming-performance-k8s/workflow.yaml
+++ b/network-streaming-performance-k8s/workflow.yaml
@@ -72,11 +72,11 @@ input:
             type_id: integer
 steps:
   uuidgen:
-    plugin: quay.io/arcalot/arcaflow-plugin-utilities:0.1.0
+    plugin: quay.io/arcalot/arcaflow-plugin-utilities:atp-comms-fix_fda07a0
     step: uuid
     input: {}
   kubeconfig:
-    plugin: quay.io/arcalot/arcaflow-plugin-kubeconfig:0.1.0
+    plugin: quay.io/arcalot/arcaflow-plugin-kubeconfig:atp-comms-fix_8330396
     input:
       kubeconfig: !expr $.input.kubeconfig
   pcp:
@@ -113,7 +113,7 @@ steps:
     input:
       run_duration: !expr $.input.uperf_server_timeout_seconds
   service:
-    plugin: quay.io/arcalot/arcaflow-plugin-service:latest
+    plugin: quay.io/arcalot/arcaflow-plugin-service:sdk-update
     input:
       connection: !expr $.steps.kubeconfig.outputs.success.connection
       service:

--- a/network-streaming-performance-k8s/workflow.yaml
+++ b/network-streaming-performance-k8s/workflow.yaml
@@ -32,7 +32,7 @@ input:
             type_id: integer
           default: 1
           required: true
-        uperf_kbytes:
+        uperf_bytes:
           display:
             description: The uperf workload packet size in KiB
             name: uperf size
@@ -72,15 +72,15 @@ input:
             type_id: integer
 steps:
   uuidgen:
-    plugin: quay.io/arcalot/arcaflow-plugin-utilities:latest
+    plugin: quay.io/arcalot/arcaflow-plugin-utilities:0.1.0
     step: uuid
     input: {}
   kubeconfig:
-    plugin: quay.io/arcalot/arcaflow-plugin-kubeconfig:latest
+    plugin: quay.io/arcalot/arcaflow-plugin-kubeconfig:0.1.0
     input:
       kubeconfig: !expr $.input.kubeconfig
   pcp:
-    plugin: quay.io/dustinblack/arcaflow-plugin-pcp-test:latest
+    plugin: quay.io/arcalot/arcaflow-plugin-pcp:0.2.0
     step: start-pcp
     input:
       pmlogger_interval: !expr $.input.pmlogger_interval
@@ -97,7 +97,7 @@ steps:
           pluginContainer:
             imagePullPolicy: Always
   uperf_server:
-    plugin: quay.io/arcalot/arcaflow-plugin-uperf:sdk-update_6fe86dd
+    plugin: quay.io/arcalot/arcaflow-plugin-uperf:latest
     step: uperf_server
     deploy:
       type: kubernetes
@@ -136,7 +136,7 @@ steps:
           selector:
             arcaflow: uperf-server
   uperf_client:
-    plugin: quay.io/arcalot/arcaflow-plugin-uperf:sdk-update_6fe86dd
+    plugin: quay.io/arcalot/arcaflow-plugin-uperf:latest
     step: uperf
     deploy:
       type: kubernetes
@@ -163,14 +163,14 @@ steps:
             - duration: !expr $.input.uperf_runtime_seconds
               flowops:
                 - type: "write"
-                  size: !expr $.input.uperf_kbytes
+                  size: !expr $.input.uperf_bytes
                 - type: "read"
-                  size: !expr $.input.uperf_kbytes
+                  size: !expr $.input.uperf_bytes
             - iterations: 1
               flowops:
                 - type: "disconnect"
   metadata:
-    plugin: quay.io/arcalot/arcaflow-plugin-metadata:latest
+    plugin: quay.io/arcalot/arcaflow-plugin-metadata:0.1.0
     deploy:
       type: kubernetes
       connection: !expr $.steps.kubeconfig.outputs.success.connection

--- a/network-streaming-performance-k8s/workflow.yaml
+++ b/network-streaming-performance-k8s/workflow.yaml
@@ -97,7 +97,7 @@ steps:
           pluginContainer:
             imagePullPolicy: Always
   uperf_server:
-    plugin: quay.io/arcalot/arcaflow-plugin-uperf:latest
+    plugin: quay.io/arcalot/arcaflow-plugin-uperf:0.2.0
     step: uperf_server
     deploy:
       type: kubernetes
@@ -113,7 +113,7 @@ steps:
     input:
       run_duration: !expr $.input.uperf_server_timeout_seconds
   service:
-    plugin: quay.io/arcalot/arcaflow-plugin-service:sdk-update
+    plugin: quay.io/arcalot/arcaflow-plugin-service:0.1.0
     input:
       connection: !expr $.steps.kubeconfig.outputs.success.connection
       service:
@@ -136,7 +136,7 @@ steps:
           selector:
             arcaflow: uperf-server
   uperf_client:
-    plugin: quay.io/arcalot/arcaflow-plugin-uperf:latest
+    plugin: quay.io/arcalot/arcaflow-plugin-uperf:0.2.0
     step: uperf
     deploy:
       type: kubernetes

--- a/network-streaming-performance-k8s/workflow.yaml
+++ b/network-streaming-performance-k8s/workflow.yaml
@@ -72,11 +72,11 @@ input:
             type_id: integer
 steps:
   uuidgen:
-    plugin: quay.io/arcalot/arcaflow-plugin-utilities:atp-comms-fix_fda07a0
+    plugin: quay.io/arcalot/arcaflow-plugin-utilities:0.2.0
     step: uuid
     input: {}
   kubeconfig:
-    plugin: quay.io/arcalot/arcaflow-plugin-kubeconfig:atp-comms-fix_8330396
+    plugin: quay.io/arcalot/arcaflow-plugin-kubeconfig:0.2.0
     input:
       kubeconfig: !expr $.input.kubeconfig
   pcp:


### PR DESCRIPTION
## Changes introduced with this PR

The network streaming performance workflow is now updated to the latest specific version of all plugin images, instead of `latest`.
Uperf now accepts bytes instead of kbytes.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).