### PR TITLE
Use multiple outputs in example workflow

### DIFF
--- a/example-workflow/workflow.yaml
+++ b/example-workflow/workflow.yaml
@@ -87,8 +87,14 @@ steps:
         pcp: !expr $.steps.pcp.outputs.success
         sysbench: !expr $.steps.sysbench.outputs.success
         metadata: !expr $.steps.metadata.outputs.success
-output:
-  pcp: !expr $.steps.pcp.outputs.success
-  sysbench: !expr $.steps.sysbench.outputs.success
-  metadata: !expr $.steps.metadata.outputs.success
-  opensearch: !expr $.steps.opensearch.outputs.success
+outputs:
+ success:
+   pcp: !expr $.steps.pcp.outputs.success
+   sysbench: !expr $.steps.sysbench.outputs.success
+   metadata: !expr $.steps.metadata.outputs.success
+   opensearch: !expr $.steps.opensearch.outputs.success
+ no-indexing:
+   pcp: !expr $.steps.pcp.outputs.success
+   sysbench: !expr $.steps.sysbench.outputs.success
+   metadata: !expr $.steps.metadata.outputs.success
+   no-index: !expr $.steps.opensearch.outputs.error


### PR DESCRIPTION
## Changes introduced with this PR

This PR makes the example workflow take advantage of multiple outputs to have a separate valid output for when indexing fails.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).